### PR TITLE
Redis-custom-pass

### DIFF
--- a/.devilbox/www/config.php
+++ b/.devilbox/www/config.php
@@ -128,7 +128,13 @@ function loadClass($class) {
 
 			case 'Redis':
 				loadFile($class, $cnt_dir);
-				$_LOADED_LIBS[$class] = \devilbox\Redis::getInstance($GLOBALS['REDIS_HOST_NAME']);
+				if(loadClass('Helper')->getEnv('REDIS_ROOT_PASSWORD') == ''){
+					$_LOADED_LIBS[$class] = \devilbox\Redis::getInstance($GLOBALS['REDIS_HOST_NAME']);
+				}else{
+					$_LOADED_LIBS[$class] = \devilbox\Redis::getInstance($GLOBALS['REDIS_HOST_NAME'], array(
+						'pass' => loadClass('Helper')->getEnv('REDIS_ROOT_PASSWORD'),
+					));
+				}
 				break;
 
 			case 'Memcd':

--- a/.devilbox/www/include/lib/container/Redis.php
+++ b/.devilbox/www/include/lib/container/Redis.php
@@ -44,6 +44,9 @@ class Redis extends BaseClass implements BaseInterface
 				$this->setConnectErrno(1);
 				//loadClass('Logger')->error($this->_connect_error);
 			} else {
+				if(array_key_exists('pass', $data)){
+					$redis->auth($data['pass']);
+				}
 				$redis->set('devilbox-version', $GLOBALS['DEVILBOX_VERSION'].' ('.$GLOBALS['DEVILBOX_DATE'].')');
 				$this->_redis = $redis;
 			}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -394,6 +394,12 @@ services:
   # ------------------------------------------------------------
   redis:
     image: redis:${REDIS_SERVER:-3.2}
+    
+    # REDIS CUSTOM PASSWORD SETUP
+    #comment out the following 3 lines if you want to set a custom redis password, also set the redis pass variable in .env
+    #command: redis-server --requirepass ${REDIS_ROOT_PASSWORD}
+    #environment:
+    #  - ALLOW_EMPTY_PASSWORD=yes
 
     ports:
       # [local-machine:]local-port:docker-port

--- a/env-example
+++ b/env-example
@@ -541,6 +541,11 @@ HOST_PORT_PGSQL=5432
 ###
 HOST_PORT_REDIS=6379
 
+###
+### Comment out to set the redis custom password also, in docker-compose.yml comment out the REDIS CUSTOM PASSWORD SETUP section
+###
+#REDIS_ROOT_PASSWORD=root
+
 
 
 ################################################################################


### PR DESCRIPTION
Adding custom password option for Redis via the .env and the docker-compose.yml (couldn't find a workaround editing the yml because of redis' require pass command - but uncommenting the lines works fine if someone wants this feature - like me)